### PR TITLE
Many features

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM abakpress/ruby-app:2.3-latest
+
+RUN git config --global user.name "Automated Release" \
+  && git config --global user.email support@railsc.ru
+
+ADD . /usr/src/apress-gems
+
+RUN cd /usr/src/apress-gems \
+  && gem build -V apress-gems.gemspec \
+  && gem install $(ls -t apress-gems*.gem | head -1)
+
+ADD release-gem /usr/local/bin/

--- a/bin/apress-gem
+++ b/bin/apress-gem
@@ -23,7 +23,7 @@ opt_parser = OptionParser.new do |opt|
   opt.separator 'Options'
 
   opt.on('-h', '--help', 'help') do
-    puts opt_parser
+    options[:show_help] = true
   end
 
   opt.on('-v', '--version VERSION', 'new version, ex: -v 1.0.0') do |value|
@@ -65,10 +65,14 @@ end
 
 opt_parser.parse!
 
-cli = Apress::Gems::Cli.new(options)
+if options[:show_help]
+  puts opt_parser
+  exit
+end
 
-if %w(release changelog build upload tag current bump exist).include?(ARGV[0])
-  cli.public_send(ARGV[0])
+subcmd = ARGV[0]
+if %w(release changelog build upload tag current bump exist).include?(subcmd)
+  Apress::Gems::Cli.new(options).public_send(subcmd)
 else
   puts opt_parser
 end

--- a/bin/apress-gem
+++ b/bin/apress-gem
@@ -17,6 +17,7 @@ opt_parser = OptionParser.new do |opt|
   opt.separator '    build: make gem package'
   opt.separator '    upload: upload package to gems.railsc.ru'
   opt.separator '    current: show current gem version'
+  opt.separator '    exist: check for uploaded gem'
   opt.separator ''
 
   opt.separator 'Options'
@@ -33,7 +34,7 @@ opt_parser = OptionParser.new do |opt|
     options[:branch] = value
   end
 
-  opt.on('-r', '--remote NAME', 'remote server name, default upstream') do |value|
+  opt.on('-r', '--remote NAME', 'remote server name, default origin') do |value|
     options[:remote] = value
   end
 
@@ -52,13 +53,17 @@ opt_parser = OptionParser.new do |opt|
   opt.on('-U', '--no-pull', 'no pull latest changes') do
     options[:pull] = false
   end
+
+  opt.on('-q', '--quiet', 'silence command progress meter') do
+    options[:quiet] = true
+  end
 end
 
 opt_parser.parse!
 
 cli = Apress::Gems::Cli.new(options)
 
-if %w(release changelog build upload tag current bump).include?(ARGV[0])
+if %w(release changelog build upload tag current bump exist).include?(ARGV[0])
   cli.public_send(ARGV[0])
 else
   puts opt_parser

--- a/bin/apress-gem
+++ b/bin/apress-gem
@@ -57,6 +57,10 @@ opt_parser = OptionParser.new do |opt|
   opt.on('-q', '--quiet', 'silence command progress meter') do
     options[:quiet] = true
   end
+
+  opt.on('-s', '--source URL', 'url of gem source, default https://gems.railsc.ru/') do |value|
+    options[:source] = value
+  end
 end
 
 opt_parser.parse!

--- a/lib/apress/gems/cli.rb
+++ b/lib/apress/gems/cli.rb
@@ -16,7 +16,8 @@ module Apress
         push: true,
         remote: "origin",
         branch: "master",
-        quiet: false
+        quiet: false,
+        source: 'https://gems.railsc.ru/'
       }.freeze
 
       def initialize(options)
@@ -56,7 +57,7 @@ module Apress
 
       def upload
         tarball_name = "#{@gemspec.name}-#{version_or_current}.gem"
-        upload_gem(upload_uri, tarball_name)
+        upload_gem(source_uri, tarball_name)
       end
 
       def tag
@@ -116,7 +117,7 @@ module Apress
       end
 
       def exist?
-        cmd = "gem search #{@gemspec.name} --clear-sources -s '#{upload_uri}' --exact --quiet -a"
+        cmd = "gem search #{@gemspec.name} --clear-sources -s '#{source_uri}' --exact --quiet -a"
         output = spawn(cmd)
         escaped_version = Regexp.escape(version_or_current)
         !!(output =~ /[( ]#{escaped_version}[,)]/)
@@ -132,10 +133,12 @@ module Apress
         end
       end
 
-      def upload_uri
-        uri = URI.parse(GEMS_URL)
-        uri.userinfo = Bundler.settings[GEMS_URL]
-        uri
+      def source_uri
+        return @uri if defined?(@uri)
+        source_url = @options.fetch(:source)
+        @uri = URI.parse(source_url)
+        @uri.userinfo = Bundler.settings[source_url]
+        @uri
       end
 
       def pull_latest

--- a/lib/apress/gems/cli.rb
+++ b/lib/apress/gems/cli.rb
@@ -9,9 +9,18 @@ module Apress
     class Cli
       GEMS_URL = 'https://gems.railsc.ru/'.freeze
 
+      DEFAULT_OPTIONS = {
+        bump: true,
+        changelog: true,
+        pull: true,
+        push: true,
+        remote: "origin",
+        branch: "master",
+        quiet: false
+      }.freeze
+
       def initialize(options)
-        @options = {bump: true, changelog: true, pull: true, push: true}.merge!(options)
-        @options[:version] = find_version unless @options[:bump]
+        @options = DEFAULT_OPTIONS.merge(options)
 
         load_gemspec
       end
@@ -19,7 +28,7 @@ module Apress
       def changelog
         Apress::ChangeLogger.new.log_changes
         spawn 'git add CHANGELOG.md'
-        puts 'Changelog generated'
+        log 'Changelog generated'
       end
 
       def bump
@@ -31,7 +40,7 @@ module Apress
 
         if @options[:push]
           spawn "git push #{remote} #{branch}"
-          puts 'Changes pushed to repository'
+          log 'Changes pushed to repository'
         end
       end
 
@@ -42,25 +51,35 @@ module Apress
         built_gem_path = Dir["#{@gemspec.name}-*.gem"].sort_by { |f| File.mtime(f) }.last
 
         FileUtils.mv(built_gem_path, 'pkg')
-        puts 'Package built'
+        log 'Package built'
       end
 
       def upload
-        tarball_name = "#{@gemspec.name}-#{version}.gem"
+        tarball_name = "#{@gemspec.name}-#{version_or_current}.gem"
         upload_gem(upload_uri, tarball_name)
       end
 
       def tag
-        tag_name = "v#{version}"
+        tag_name = "v#{version_or_current}"
 
-        spawn "git tag -a -m \"Version #{version}\" #{tag_name}"
+        spawn "git tag -a -m \"Version #{version_or_current}\" #{tag_name}"
         spawn "git push --tags #{remote}" if @options[:push]
 
-        puts "Git tag generated to #{tag_name}"
+        log "Git tag generated to #{tag_name}"
       end
 
       def current
-        puts "Current version is #{find_version}"
+        puts find_version
+      end
+
+      def exist
+        if exist?
+          log "Gem already released"
+          exit(0)
+        else
+          log "Gem is not released"
+          exit(1)
+        end
       end
 
       def release
@@ -77,12 +96,16 @@ module Apress
         @version ||= @options.fetch(:version)
       end
 
+      def version_or_current
+        @version_or_current ||= @options.fetch(:version, find_version)
+      end
+
       def branch
-        @branch ||= @options.fetch(:branch, 'master')
+        @branch ||= @options.fetch(:branch)
       end
 
       def remote
-        @remote ||= @options.fetch(:remote, 'upstream')
+        @remote ||= @options.fetch(:remote)
       end
 
       def find_version
@@ -92,13 +115,20 @@ module Apress
         end
       end
 
+      def exist?
+        cmd = "gem search #{@gemspec.name} --clear-sources -s '#{upload_uri}' --exact --quiet -a"
+        output = spawn(cmd)
+        escaped_version = Regexp.escape(version_or_current)
+        !!(output =~ /[( ]#{escaped_version}[,)]/)
+      end
+
       def update_version
         Dir['lib/**/version.rb'].each do |file|
           contents = File.read(file)
-          contents.gsub!(/VERSION\s*=\s*(['"])(.*?)\1/m, "VERSION = '#{version}'")
+          contents.gsub!(/VERSION\s*=\s*(['"])(.*?)\1/m, "VERSION = '#{version}'.freeze")
           File.write(file, contents)
           spawn "git add #{file}"
-          puts "Version updated to #{version}"
+          log "Version updated to #{version}"
         end
       end
 
@@ -109,8 +139,6 @@ module Apress
       end
 
       def pull_latest
-        `git rev-parse --abbrev-ref HEAD`.chomp.strip == branch || abort("Can be released only from `#{branch}` branch")
-        `git remote | grep #{remote}`.chomp.strip == remote || abort("Can be released only with `#{remote}` remote")
         spawn "git pull #{remote} #{branch}"
         spawn "git fetch --tags #{remote}"
       end
@@ -126,13 +154,17 @@ module Apress
 
       # run +cmd+ in subprocess, redirect its stdout to parent's stdout
       def spawn(cmd)
-        puts ">> #{cmd}"
+        log ">> #{cmd}"
 
         cmd += ' 2>&1'
+        output = ""
         PTY.spawn cmd do |r, _w, pid|
           begin
             r.sync
-            r.each_char { |chr| STDOUT.write(chr) }
+            r.each_char do |chr|
+              STDOUT.write(chr) unless @options[:quiet]
+              output << chr
+            end
           rescue Errno::EIO
             # simply ignoring this
           ensure
@@ -140,6 +172,8 @@ module Apress
           end
         end
         abort "#{cmd} failed, exit code #{$? && $?.exitstatus}" unless $? && $?.exitstatus == 0
+
+        output.strip
       end
 
       def load_gemspec
@@ -152,7 +186,7 @@ module Apress
       def upload_gem(repo_uri, tarball_name)
         repo_uri.path = '/upload'
 
-        puts "Start uploading gem #{tarball_name} to #{repo_uri.host}"
+        log "Start uploading gem #{tarball_name} to #{repo_uri.host}"
 
         tarball_path = File.join('pkg', tarball_name)
 
@@ -167,12 +201,17 @@ module Apress
           end
 
           if [200, 302].include?(res.code.to_i)
-            puts "#{tarball_name} uploaded successfully"
+            log "#{tarball_name} uploaded successfully"
           else
             $stderr.puts "Cannot upload #{tarball_name}. Response status: #{res.code}"
             exit(1)
           end
         end
+      end
+
+      def log(message)
+        return if @options[:quiet]
+        puts message
       end
     end
   end

--- a/release-gem
+++ b/release-gem
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+apress-gem exist --quiet || apress-gem release --no-bump --no-pull


### PR DESCRIPTION
Пришлось переотправить реквест, ибо после того как репу сделали публичной, все форки превратились в тыкву.

По многочисленным просьбам трудящихся, благодаря этим изменениям, можно будет отказаться от релизной ветки в геме. То есть зарелизить гем можно будет в один реквест.

```yaml
  release:
    image: abakpress/gem-publication:latest
    pull: true
    when:
      event: push
    commands:
      - release-gem
```

Из локальной консоли генерим версию и changelog

```
apress-gem bump -v 1.0.0
```

И отправляем пулреквест (можно тоже из [консоли](https://github.com/github/hub))

Breaking change!!! по дефолту апстрим теперь это origin. Для чего? Во-первых чтобы не писать каждый раз `apress-gem bump -v 1.0.0 --remote origin`. Во-вторых, и это самое важное, чтобы случайно не забыть и не запушить прямо в апстрим минуя ревью.