### PR TITLE
fix: REGEXP for version update

### DIFF
--- a/lib/apress/gems/cli.rb
+++ b/lib/apress/gems/cli.rb
@@ -124,7 +124,7 @@ module Apress
       def update_version
         Dir['lib/**/version.rb'].each do |file|
           contents = File.read(file)
-          contents.gsub!(/VERSION\s*=\s*(['"])(.*?)\1/m, "VERSION = '#{version}'.freeze")
+          contents.gsub!(/VERSION\s*=\s*(['"])(.*?)\1.*/m, "VERSION = '#{version}'.freeze")
           File.write(file, contents)
           spawn "git add #{file}"
           log "Version updated to #{version}"


### PR DESCRIPTION
Проблема:
```
irb(main):004:0> "VERSION = '1.2.3'.freeze".gsub(/VERSION\s*=\s*(['"])(.*?)\1/m, "VERSION = '1.3.4'.freeze")
=> "VERSION = '1.3.4'.freeze.freeze"
```

Новый регексп:
```
irb(main):008:0> "VERSION = '1.2.3'".gsub(/VERSION\s*=\s*(['"])(.*?)\1.*/m, "VERSION = '1.3.4'.freeze")
=> "VERSION = '1.3.4'.freeze"
irb(main):009:0> "VERSION = '1.2.3'.freeze".gsub(/VERSION\s*=\s*(['"])(.*?)\1.*/m, "VERSION = '1.3.4'.freeze")
=> "VERSION = '1.3.4'.freeze"
```
